### PR TITLE
docs: Change prisma script

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -25,7 +25,7 @@ Aby backend poprawnie się uruchomił musi być uruchomiana baza danych za pomoc
 Trzymać się dobrych praktyk opisanych w dokumentacji Nest'a (np. używanie CLI do generowania templateów). Używać Prettier'a do formatowania kodu. Commity, Issue oraz Pull Requesty opisywać w sposób czytelny/autodokumnentujący się.
 
 ### Prisma ORM
-Po dodaniu modelu/i do [schematu Prismy](./prisma/schema.prisma) należy wykonać polecenie `npm -w server run prisma:generate`. Wygeneruje ono typy oraz definicje klas dla opiektów z bazy. UWAGA! Po genereacji może być konieczne zrestartowanie IDE. ww. polecenie należy również wykonać przy pierwszym uruchomieniu projektu. Wymagane też jest ustawienie pliku [.env](.env) zgodnie z plikiem [.env.example](.env.example).
+Po dodaniu modelu/i do [schematu Prismy](./prisma/schema.prisma) należy wykonać polecenie `npm -w server run prisma:migrate`. Wygeneruje ono typy oraz definicje klas dla opiektów z bazy. UWAGA! Po genereacji może być konieczne zrestartowanie IDE. ww. polecenie należy również wykonać przy pierwszym uruchomieniu projektu. Wymagane też jest ustawienie pliku [.env](.env) zgodnie z plikiem [.env.example](.env.example).
 
 ## Przydatne linki + info
 - [Dokumentacja Nest.js](https://docs.nestjs.com/)

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,7 +15,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "prisma:generate": "prisma generate"
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",


### PR DESCRIPTION
Changes prisma script from `prisma:generate` to `prisma:migrate`, which assures the DB to be in sync with the Prisma Schema.